### PR TITLE
Move browser action to page action

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,8 +24,14 @@
   },
   "page_action": {
     "show_matches": ["*://*/*"],
-    "hide_matches": ["*://www.instapaper.com/*"],
+    "hide_matches": [
+      "*://www.instapaper.com/u*",
+      "*://www.instapaper.com/read/*",
+      "*://www.instapaper.com/api/*",
+      "*://www.instapaper.com/text?u=*"
+    ],
     "default_popup": "browserAction.html",
+    "default_title": "Read with Instapaper",
     "browser_style": true,
     "default_icon": {
       "16": "icons/icon.svg",

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,9 @@
       "scripts/background.js"
     ]
   },
-  "browser_action": {
+  "page_action": {
+    "show_matches": ["*://*/*"],
+    "hide_matches": ["*://www.instapaper.com/*"],
     "default_popup": "browserAction.html",
     "browser_style": true,
     "default_icon": {
@@ -30,7 +32,7 @@
       "19": "icons/icon.svg",
       "24": "icons/icon.svg",
       "32": "icons/icon.svg",
-      "38": "icons/icon.svg"
+      "64": "icons/icon.svg"
     }
   },
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,7 @@
       "19": "icons/icon.svg",
       "24": "icons/icon.svg",
       "32": "icons/icon.svg",
-      "64": "icons/icon.svg"
+      "38": "icons/icon.svg"
     }
   },
   "icons": {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -292,6 +292,13 @@ function PostOffice(request, sender, sendResponse)
 }
 browser.runtime.onMessage.addListener(PostOffice);
 
+browser.tabs.onUpdated.addListener((id, changeInfo, tab) => {
+    if(isInstapaperReadingUrl(tab.url)) {
+      browser.pageAction.hide(id)
+    } else {
+      browser.pageAction.show(id)
+    }
+});
 
 // Initialize
 getAuthorization();


### PR DESCRIPTION
Hello @da2x 
I'm a long-time Instapaper and Firefox user so this Addon is greatly appreciated.
And I definetely enjoyed your `Web Reading Mode` series, too. So, thanks!

Here,
I think using [pageAction](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction) is a little more contextual, and allow the extension to behave more like the Pocket integration.

|Before|After|
|--|--|
|<img width="392" alt="final-before" src="https://user-images.githubusercontent.com/6209647/50824881-fb320880-1337-11e9-90d7-0fbfc3a584bb.png">|<img width="410" alt="final-after" src="https://user-images.githubusercontent.com/6209647/50824882-fb320880-1337-11e9-8085-ba3e8d86b0d1.png">|