### PR TITLE
New icon for pageAction

### DIFF
--- a/icons/pageAction.svg
+++ b/icons/pageAction.svg
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Livello_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#666666;}
-</style>
-<path class="st0" d="M13,0H3C1.9,0,1,0.9,1,2v12c0,1.1,0.9,2,2,2h10c1.1,0,2-0.9,2-2V2C15,0.9,14.1,0,13,0z M13,13c0,0.6-0.4,1-1,1
-	H4c-0.6,0-1-0.4-1-1V3c0-0.6,0.4-1,1-1h8c0.6,0,1,0.4,1,1V13z"/>
-<polygon class="st0" points="10,5.4 8.7,5.4 8.7,10.6 10,10.6 10,12 6,12 6,10.6 7.3,10.6 7.3,5.4 6,5.4 6,4 10,4 "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 16 16" width="16">
+  <path fill="#666" d="M13 0H3C1.9 0 1 .9 1 2v12c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V2c0-1.1-.9-2-2-2zm0 13c0 .6-.4 1-1 1H4c-.6 0-1-.4-1-1V3c0-.6.4-1 1-1h8c.6 0 1 .4 1 1v10z"/>
+  <path fill="#666" d="M10 5.4H8.7v5.2H10V12H6v-1.4h1.3V5.4H6V4h4z"/>
 </svg>

--- a/icons/pageAction.svg
+++ b/icons/pageAction.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Livello_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#666666;}
+</style>
+<path class="st0" d="M13,0H3C1.9,0,1,0.9,1,2v12c0,1.1,0.9,2,2,2h10c1.1,0,2-0.9,2-2V2C15,0.9,14.1,0,13,0z M13,13c0,0.6-0.4,1-1,1
+	H4c-0.6,0-1-0.4-1-1V3c0-0.6,0.4-1,1-1h8c0.6,0,1,0.4,1,1V13z"/>
+<polygon class="st0" points="10,5.4 8.7,5.4 8.7,10.6 10,10.6 10,12 6,12 6,10.6 7.3,10.6 7.3,5.4 6,5.4 6,4 10,4 "/>
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -34,11 +34,11 @@
     "default_title": "Read with Instapaper",
     "browser_style": true,
     "default_icon": {
-      "16": "icons/icon.svg",
-      "19": "icons/icon.svg",
-      "24": "icons/icon.svg",
-      "32": "icons/icon.svg",
-      "38": "icons/icon.svg"
+      "16": "icons/pageAction.svg",
+      "19": "icons/pageAction.svg",
+      "24": "icons/pageAction.svg",
+      "32": "icons/pageAction.svg",
+      "38": "icons/pageAction.svg"
     }
   },
   "icons": {


### PR DESCRIPTION
This is a little follow-up for #1 
A try to mimic even more the pocket integrated addon by adding an icon that follows the photon design.

Given the limitations of the actual Firefox theming API for what concerns pageAction (specificly dark/light themes detection), I'm not really fond with the result. The icon itself is not my masterpiece.

Feel free to discard this PR, still the idea seems worth consideration.